### PR TITLE
fix: 修复build:prod打包出来白屏问题

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -18,7 +18,7 @@ const getEntry = function() {
       // 在 dist/index.html 的输出
       filename: `${fileName}/index.html`,
       // 提取出来的通用 chunk 和 vendor chunk。
-      chunks: ['chunk-libs', 'chunk-elementUI', 'chunk-common', fileName],
+      chunks: ['chunk-libs', 'chunk-vue', 'chunk-elementUI', 'chunk-common', fileName],
       minify: {
         removeComments: true,
         collapseWhitespace: true,


### PR DESCRIPTION
- build:prod打包出来白屏，原因是webpack编译后的chunk.vue.js是通过ilnk preload引入，导致页面没来得及渲染，故需在入口处增加splitChunks 的 chunk-vue
- 默认在服务器解析域名到dist后会看到webpack template，需在web服务器做重定向到default或system模块