### PR TITLE
feat:SupperButton componentProps 深拷贝后再传入自定义组件

### DIFF
--- a/src/components/Common/SuperButton.vue
+++ b/src/components/Common/SuperButton.vue
@@ -290,6 +290,7 @@ export default {
       return strVarReplace(str, data)
     },
     transProps(componentProps) {
+      componentProps = this._.cloneDeep(componentProps)
       Object.keys(componentProps).forEach(item => {
         if (type(componentProps[item]) === 'string') {
           componentProps[item] = strVarReplace(componentProps[item], this.$props.baseData)


### PR DESCRIPTION
componentProps 在传入自定义组件前会进行模板参数的替换，这是破坏性的修改，所以应该进行深拷贝，以免影响其它用到 componentProps 的地方